### PR TITLE
fixed validation-layer of bindDescriptorSets

### DIFF
--- a/src/Vulkan/LLGI.CommandListVulkan.cpp
+++ b/src/Vulkan/LLGI.CommandListVulkan.cpp
@@ -281,7 +281,7 @@ void CommandListVulkan::Draw(int32_t pritimiveCount)
 
 		if (firstSet < 0)
 		{
-			firstSet = i;
+			firstSet = descriptorIndex;
 		}
 
 		descriptorIndex++;


### PR DESCRIPTION
Crash when using uniform with fragment shader only.