### PR TITLE
implement stencil test on Metal

### DIFF
--- a/src/Metal/LLGI.CommandListMetal.mm
+++ b/src/Metal/LLGI.CommandListMetal.mm
@@ -59,6 +59,19 @@ void CommandList_Impl::BeginRenderPass(RenderPass_Impl* renderPass)
 	{
 		renderPass->renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionDontCare;
 	}
+	
+	if (renderPass->isDepthCleared)
+	{
+		renderPass->renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
+		renderPass->renderPassDescriptor.depthAttachment.clearDepth = 1.0;
+		renderPass->renderPassDescriptor.stencilAttachment.loadAction = MTLLoadActionClear;
+		renderPass->renderPassDescriptor.stencilAttachment.clearStencil = 0;
+	}
+	else
+	{
+		renderPass->renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionDontCare;
+		renderPass->renderPassDescriptor.stencilAttachment.loadAction = MTLLoadActionDontCare;
+	}
 
 	renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPass->renderPassDescriptor];
 }
@@ -223,6 +236,8 @@ void CommandListMetal::Draw(int32_t pritimiveCount)
 	if (isPipDirtied)
 	{
 		[impl->renderEncoder setRenderPipelineState:pip->GetImpl()->pipelineState];
+        [impl->renderEncoder setDepthStencilState:pip->GetImpl()->depthStencilState];
+		[impl->renderEncoder setStencilReferenceValue:0xFF];
 	}
 
 	// draw

--- a/src/Metal/LLGI.GraphicsMetal.h
+++ b/src/Metal/LLGI.GraphicsMetal.h
@@ -20,8 +20,9 @@ class TextureMetal;
 struct RenderPassPipelineStateMetalKey
 {
     MTLPixelFormat format;
+	MTLPixelFormat depthStencilFormat = MTLPixelFormatInvalid;	// MTLPixelFormatInvalid if texture is not set.
         
-    bool operator==(const RenderPassPipelineStateMetalKey& value) const { return (format == value.format); }
+    bool operator==(const RenderPassPipelineStateMetalKey& value) const { return (format == value.format && depthStencilFormat == value.depthStencilFormat); }
         
     struct Hash
     {
@@ -29,7 +30,7 @@ struct RenderPassPipelineStateMetalKey
             
         std::size_t operator()(const RenderPassPipelineStateMetalKey& key) const
         {
-            return std::hash<std::int32_t>()(static_cast<int>(key.format));
+            return std::hash<std::int32_t>()(static_cast<int>(key.format) + (static_cast<int>(key.depthStencilFormat) * 10000));
         }
     };
 };
@@ -85,7 +86,7 @@ public:
 	Texture* CreateTexture(uint64_t id) override;
 
     //! internal function
-	std::shared_ptr<RenderPassPipelineStateMetal> CreateRenderPassPipelineState(MTLPixelFormat format);
+	std::shared_ptr<RenderPassPipelineStateMetal> CreateRenderPassPipelineState(MTLPixelFormat format, MTLPixelFormat depthStencilFormat);
 
     RenderPassPipelineState* CreateRenderPassPipelineState(RenderPass* renderPass) override;
     

--- a/src/Metal/LLGI.GraphicsMetal.mm
+++ b/src/Metal/LLGI.GraphicsMetal.mm
@@ -195,10 +195,11 @@ Texture* GraphicsMetal::CreateTexture(const Vec2I& size, bool isRenderPass, bool
 
 Texture* GraphicsMetal::CreateTexture(uint64_t id) { throw "Not inplemented"; }
 
-std::shared_ptr<RenderPassPipelineStateMetal> GraphicsMetal::CreateRenderPassPipelineState(MTLPixelFormat format)
+std::shared_ptr<RenderPassPipelineStateMetal> GraphicsMetal::CreateRenderPassPipelineState(MTLPixelFormat format, MTLPixelFormat depthStencilFormat)
 {
 	RenderPassPipelineStateMetalKey key;
 	key.format = format;
+	key.depthStencilFormat = depthStencilFormat;
 
 	// already?
 	{
@@ -215,6 +216,7 @@ std::shared_ptr<RenderPassPipelineStateMetal> GraphicsMetal::CreateRenderPassPip
 
 	std::shared_ptr<RenderPassPipelineStateMetal> ret = LLGI::CreateSharedPtr<>(new RenderPassPipelineStateMetal());
 	ret->GetImpl()->pixelFormat = format;
+	ret->GetImpl()->depthStencilFormat = depthStencilFormat;
 
 	renderPassPipelineStates[key] = ret;
 
@@ -225,7 +227,8 @@ RenderPassPipelineState* GraphicsMetal::CreateRenderPassPipelineState(RenderPass
 {
     auto renderPass_ = static_cast<RenderPassMetal*>(renderPass);
     
-    auto renderPassPipelineState = CreateRenderPassPipelineState(renderPass_->GetImpl()->pixelFormat);
+    auto renderPassPipelineState = CreateRenderPassPipelineState(
+		renderPass_->GetImpl()->pixelFormat, renderPass_->GetImpl()->depthStencilFormat);
 
     auto ret = renderPassPipelineState.get();
     SafeAddRef(ret);

--- a/src/Metal/LLGI.Metal_Impl.h
+++ b/src/Metal/LLGI.Metal_Impl.h
@@ -31,6 +31,7 @@ struct RenderPass_Impl
 	bool isColorCleared;
 	bool isDepthCleared;
 	MTLPixelFormat pixelFormat = MTLPixelFormatBGRA8Unorm;
+	MTLPixelFormat depthStencilFormat = MTLPixelFormatInvalid;
 
 	RenderPass_Impl();
 	~RenderPass_Impl();
@@ -42,6 +43,7 @@ struct RenderPass_Impl
 struct RenderPassPipelineState_Impl
 {
 	MTLPixelFormat pixelFormat = MTLPixelFormatBGRA8Unorm;
+	MTLPixelFormat depthStencilFormat = MTLPixelFormatInvalid;
 };
 
 struct CommandList_Impl

--- a/src/Metal/LLGI.RenderPassMetal.mm
+++ b/src/Metal/LLGI.RenderPassMetal.mm
@@ -48,6 +48,8 @@ void RenderPass_Impl::UpdateTarget(Texture_Impl** textures, int32_t textureCount
     if(depthTexture != nullptr)
     {
         renderPassDescriptor.depthAttachment.texture = depthTexture->texture;
+		renderPassDescriptor.stencilAttachment.texture = depthTexture->texture;
+		depthStencilFormat = depthTexture->texture.pixelFormat;
     }
     
     pixelFormat = textures[0]->texture.pixelFormat;

--- a/src_test/test_depth_stencil.cpp
+++ b/src_test/test_depth_stencil.cpp
@@ -21,18 +21,34 @@ void test_depth_stencil(LLGI::DeviceType deviceType, bool is_test_depth, bool is
 
 	TestHelper::CreateShader(graphics.get(), deviceType, "simple_rectangle.vert", "simple_rectangle.frag", shader_vs, shader_ps);
 
+	// Green: near
 	std::shared_ptr<LLGI::VertexBuffer> vb1;
 	std::shared_ptr<LLGI::IndexBuffer> ib1;
 	TestHelper::CreateRectangle(
-		graphics.get(), LLGI::Vec3F(-0.5, 0.5, 0.5), LLGI::Vec3F(0.5, -0.5, 0.5), LLGI::Color8(), LLGI::Color8(), vb1, ib1);
+		graphics.get(), LLGI::Vec3F(-0.5, 0.5, 0.5), LLGI::Vec3F(0.5, -0.5, 0.5), LLGI::Color8(0, 255, 0, 255), LLGI::Color8(), vb1, ib1);
 
+	// Blue: far
 	std::shared_ptr<LLGI::VertexBuffer> vb2;
 	std::shared_ptr<LLGI::IndexBuffer> ib2;
 	TestHelper::CreateRectangle(
-		graphics.get(), LLGI::Vec3F(-0.2, 0.2, 0.8), LLGI::Vec3F(0.7, -0.7, 0.8), LLGI::Color8(), LLGI::Color8(), vb2, ib2);
+		graphics.get(), LLGI::Vec3F(-0.2, 0.2, 0.8), LLGI::Vec3F(0.7, -0.7, 0.8), LLGI::Color8(0, 0, 255, 255), LLGI::Color8(), vb2, ib2);
 
-	std::map<std::shared_ptr<LLGI::RenderPassPipelineState>, std::shared_ptr<LLGI::PipelineState>> pips;
+	struct PipelineStateSet
+	{
+		std::shared_ptr<LLGI::PipelineState> writeState;	// write depth or stencil
+		std::shared_ptr<LLGI::PipelineState> testState;	    // depth-test or stencil-test
+	};
+	std::map<std::shared_ptr<LLGI::RenderPassPipelineState>, PipelineStateSet> pips;
+	
+	
+	//auto screenRenderPass = graphics->GetCurrentScreen(color, true, true);
+	//auto depthBuffer = graphics->CreateTexture(LLGI::Vec2I(256, 256), false, true);
+	
+	// <SwapChainRenderPass, BackbufferDepthBuffer>
+	std::array<LLGI::Texture*, 3> depthBuffers = {};
+	std::array<LLGI::RenderPass*, 3> renderPasses = {};
 
+	
 	while (count < 1000)
 	{
 		platform->NewFrame();
@@ -44,52 +60,100 @@ void test_depth_stencil(LLGI::DeviceType deviceType, bool is_test_depth, bool is
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = graphics->GetCurrentScreen(color, true, true);
+		int swapIndex = count % 3;
+		auto screenRenderPass = graphics->GetCurrentScreen(color, true, true);
+		LLGI::RenderPass* renderPass;
+		if (!renderPasses[swapIndex])
+		{
+			auto colorBuffer = screenRenderPass->GetColorBuffer(0);
+			auto depthBuffer = graphics->CreateTexture(colorBuffer->GetSizeAs2D(), false, true);
+			renderPass = graphics->CreateRenderPass((const LLGI::Texture**)&colorBuffer, 1, depthBuffer);
+			depthBuffers[swapIndex] = depthBuffer;
+			renderPasses[swapIndex] = renderPass;
+		}
+		else
+		{
+			renderPass = renderPasses[swapIndex];
+		}
+		renderPass->SetIsColorCleared(true);
+		renderPass->SetClearColor(color);
+		renderPass->SetIsDepthCleared(true);
+		
+		
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(renderPass->CreateRenderPassPipelineState());
 
 		if (pips.count(renderPassPipelineState) == 0)
 		{
-			auto pip = graphics->CreatePiplineState();
-			pip->VertexLayouts[0] = LLGI::VertexLayoutFormat::R32G32B32_FLOAT;
-			pip->VertexLayouts[1] = LLGI::VertexLayoutFormat::R32G32_FLOAT;
-			pip->VertexLayouts[2] = LLGI::VertexLayoutFormat::R8G8B8A8_UNORM;
-			pip->VertexLayoutNames[0] = "POSITION";
-			pip->VertexLayoutNames[1] = "UV";
-			pip->VertexLayoutNames[2] = "COLOR";
-			pip->VertexLayoutCount = 3;
+			auto writepip = graphics->CreatePiplineState();
+			writepip->VertexLayouts[0] = LLGI::VertexLayoutFormat::R32G32B32_FLOAT;
+			writepip->VertexLayouts[1] = LLGI::VertexLayoutFormat::R32G32_FLOAT;
+			writepip->VertexLayouts[2] = LLGI::VertexLayoutFormat::R8G8B8A8_UNORM;
+			writepip->VertexLayoutNames[0] = "POSITION";
+			writepip->VertexLayoutNames[1] = "UV";
+			writepip->VertexLayoutNames[2] = "COLOR";
+			writepip->VertexLayoutCount = 3;
 
-			pip->Culling = LLGI::CullingMode::DoubleSide; // TEMP :vulkan
+			writepip->Culling = LLGI::CullingMode::DoubleSide; // TEMP :vulkan
+			
+			writepip->IsBlendEnabled = false;
+			
+			if (is_test_depth)
+			{
+				writepip->IsDepthWriteEnabled = true;
+			}
+
+			writepip->SetShader(LLGI::ShaderStageType::Vertex, shader_vs.get());
+			writepip->SetShader(LLGI::ShaderStageType::Pixel, shader_ps.get());
+			writepip->SetRenderPassPipelineState(renderPassPipelineState.get());
+			writepip->Compile();
+			
+			
+			
+			auto testpip = graphics->CreatePiplineState();
+			testpip->VertexLayouts[0] = LLGI::VertexLayoutFormat::R32G32B32_FLOAT;
+			testpip->VertexLayouts[1] = LLGI::VertexLayoutFormat::R32G32_FLOAT;
+			testpip->VertexLayouts[2] = LLGI::VertexLayoutFormat::R8G8B8A8_UNORM;
+			testpip->VertexLayoutNames[0] = "POSITION";
+			testpip->VertexLayoutNames[1] = "UV";
+			testpip->VertexLayoutNames[2] = "COLOR";
+			testpip->VertexLayoutCount = 3;
+
+			testpip->Culling = LLGI::CullingMode::DoubleSide; // TEMP :vulkan
+			
+			testpip->IsBlendEnabled = false;
 
 			if (is_test_depth)
 			{
-				pip->IsDepthTestEnabled = true;
-				pip->IsDepthWriteEnabled = true;	
+				testpip->IsDepthTestEnabled = true;
 			}
 
 			if (is_test_stencil)
 			{
-				pip->IsStencilTestEnabled = true;
+				testpip->IsStencilTestEnabled = true;
 			}
 
-			pip->SetShader(LLGI::ShaderStageType::Vertex, shader_vs.get());
-			pip->SetShader(LLGI::ShaderStageType::Pixel, shader_ps.get());
-			pip->SetRenderPassPipelineState(renderPassPipelineState.get());
-			pip->Compile();
+			testpip->SetShader(LLGI::ShaderStageType::Vertex, shader_vs.get());
+			testpip->SetShader(LLGI::ShaderStageType::Pixel, shader_ps.get());
+			testpip->SetRenderPassPipelineState(renderPassPipelineState.get());
+			testpip->Compile();
 
-			pips[renderPassPipelineState] = LLGI::CreateSharedPtr(pip);
+			pips[renderPassPipelineState].writeState = LLGI::CreateSharedPtr(writepip);
+			pips[renderPassPipelineState].testState = LLGI::CreateSharedPtr(testpip);
 		}
 
 		commandList->Begin();
 		commandList->BeginRenderPass(renderPass);
 
+		// First, green rectangle.
 		commandList->SetVertexBuffer(vb1.get(), sizeof(SimpleVertex), 0);
 		commandList->SetIndexBuffer(ib1.get());
-		commandList->SetPipelineState(pips[renderPassPipelineState].get());
+		commandList->SetPipelineState(pips[renderPassPipelineState].writeState.get());
 		commandList->Draw(2);
 
+		// Next, blue rectangle.
 		commandList->SetVertexBuffer(vb2.get(), sizeof(SimpleVertex), 0);
 		commandList->SetIndexBuffer(ib2.get());
-		commandList->SetPipelineState(pips[renderPassPipelineState].get());
+		commandList->SetPipelineState(pips[renderPassPipelineState].testState.get());
 		commandList->Draw(2);
 
 		commandList->EndRenderPass();
@@ -101,6 +165,8 @@ void test_depth_stencil(LLGI::DeviceType deviceType, bool is_test_depth, bool is
 		count++;
 	}
 
+	for (auto& ptr : depthBuffers) LLGI::SafeRelease(ptr);
+	for (auto& ptr : renderPasses) LLGI::SafeRelease(ptr);
 	pips.clear();
 
 	graphics->WaitFinish();


### PR DESCRIPTION
- Implement depth and stencil attachment in RenderPass. (set pixel format)
- Implement RenderPass::SetIsDepthCleared. (clear depth and stencil)
- Add stencil-test settings to PipelineState.
  - IsStencilTestEnabled == False : Always write 0xFF to stencil buffer.
  - IsStencilTestEnabled == True : Draw if equal to 0xFF.
- Test changed to use two states. (stencil-write and stencil-test)