### PR TITLE
fixed vulkan validation

### DIFF
--- a/src/Vulkan/LLGI.RenderPassPipelineStateCacheVulkan.cpp
+++ b/src/Vulkan/LLGI.RenderPassPipelineStateCacheVulkan.cpp
@@ -71,14 +71,16 @@ RenderPassPipelineStateVulkan* RenderPassPipelineStateCacheVulkan::Create(bool i
 
 	if (isPresentMode)
 	{
-		attachmentDescs.at(0).initialLayout = vk::ImageLayout::ePresentSrcKHR;
+		// When clearing, the initialLayout does not matter.
+		attachmentDescs.at(0).initialLayout = (isColorCleared) ? vk::ImageLayout::eUndefined : vk::ImageLayout::ePresentSrcKHR;
 		attachmentDescs.at(0).finalLayout = vk::ImageLayout::ePresentSrcKHR;
 	}
 	else
 	{
 		for (int i = 0; i < colorCount; i++)
 		{
-			attachmentDescs.at(i).initialLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
+			// When clearing, the initialLayout does not matter.
+			attachmentDescs.at(i).initialLayout = (isColorCleared) ? vk::ImageLayout::eUndefined : vk::ImageLayout::eShaderReadOnlyOptimal;
 			attachmentDescs.at(i).finalLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 		}
 	}
@@ -89,7 +91,7 @@ RenderPassPipelineStateVulkan* RenderPassPipelineStateCacheVulkan::Create(bool i
 		attachmentDescs.at(colorCount).format = vk::Format::eD32SfloatS8Uint;
 		attachmentDescs.at(colorCount).samples = vk::SampleCountFlagBits::e1;
 
-		if (isColorCleared)
+		if (isDepthCleared)
 			attachmentDescs.at(colorCount).loadOp = vk::AttachmentLoadOp::eClear;
 		else
 			attachmentDescs.at(colorCount).loadOp = vk::AttachmentLoadOp::eDontCare;
@@ -97,7 +99,9 @@ RenderPassPipelineStateVulkan* RenderPassPipelineStateCacheVulkan::Create(bool i
 		attachmentDescs.at(colorCount).storeOp = vk::AttachmentStoreOp::eStore;
 		attachmentDescs.at(colorCount).stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
 		attachmentDescs.at(colorCount).stencilStoreOp = vk::AttachmentStoreOp::eStore;
-		attachmentDescs.at(colorCount).initialLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+
+		// When clearing, the initialLayout does not matter.
+		attachmentDescs.at(colorCount).initialLayout = (isDepthCleared) ? vk::ImageLayout::eUndefined : vk::ImageLayout::eDepthStencilAttachmentOptimal;
 		attachmentDescs.at(colorCount).finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 	}
 

--- a/src_test/test_clear.cpp
+++ b/src_test/test_clear.cpp
@@ -33,7 +33,7 @@ void test_clear_update(LLGI::DeviceType deviceType)
 		commandList->WaitUntilCompleted();
 
 		commandList->Begin();
-		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true));
+		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, true));
 		commandList->EndRenderPass();
 		commandList->End();
 
@@ -96,7 +96,7 @@ void test_clear(LLGI::DeviceType deviceType)
 		commandList->WaitUntilCompleted();
 
 		commandList->Begin();
-		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true));
+		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, true));
 		commandList->EndRenderPass();
 		commandList->End();
 

--- a/src_test/test_clear.cpp
+++ b/src_test/test_clear.cpp
@@ -33,7 +33,7 @@ void test_clear_update(LLGI::DeviceType deviceType)
 		commandList->WaitUntilCompleted();
 
 		commandList->Begin();
-		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, true));
+		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, false));	// TODO: isDepthClear is false, because it fails with dx12.
 		commandList->EndRenderPass();
 		commandList->End();
 
@@ -96,7 +96,7 @@ void test_clear(LLGI::DeviceType deviceType)
 		commandList->WaitUntilCompleted();
 
 		commandList->Begin();
-		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, true));
+		commandList->BeginRenderPass(platform->GetCurrentScreen(color, true, false));	// TODO: isDepthClear is false, because it fails with dx12.
 		commandList->EndRenderPass();
 		commandList->End();
 

--- a/src_test/test_renderPass.cpp
+++ b/src_test/test_renderPass.cpp
@@ -945,7 +945,7 @@ void test_capture(LLGI::DeviceType deviceType)
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, false);	// TODO: isDepthClear is false, because it fails with dx12.
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)

--- a/src_test/test_simple_render.cpp
+++ b/src_test/test_simple_render.cpp
@@ -54,7 +54,7 @@ void test_simple_rectangle(LLGI::DeviceType deviceType)
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, false);	// TODO: isDepthClear is false, because it fails with dx12.
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)

--- a/src_test/test_simple_render.cpp
+++ b/src_test/test_simple_render.cpp
@@ -54,7 +54,7 @@ void test_simple_rectangle(LLGI::DeviceType deviceType)
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, true);
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)
@@ -157,7 +157,7 @@ void test_index_offset(LLGI::DeviceType deviceType)
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, false);	// TODO: isDepthClear is false, because it fails with dx12.
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)
@@ -480,7 +480,7 @@ float4 main(PS_INPUT input) : SV_TARGET
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, false);	// TODO: isDepthClear is false, because it fails with dx12.
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)
@@ -778,7 +778,7 @@ float4 main(PS_INPUT input) : SV_TARGET
 		color.B = 0;
 		color.A = 255;
 
-		auto renderPass = platform->GetCurrentScreen(color, true);
+		auto renderPass = platform->GetCurrentScreen(color, true, false);	// TODO: isDepthClear is false, because it fails with dx12.
 		auto renderPassPipelineState = LLGI::CreateSharedPtr(graphics->CreateRenderPassPipelineState(renderPass));
 
 		if (pips.count(renderPassPipelineState) == 0)


### PR DESCRIPTION
All tests were confirmed with Vulkan.

However, some isDepthClear is false because it fails with dx12.