### PR TITLE
Use c++14 for depcreated attribute

### DIFF
--- a/examples/ImGuiPlatform/CMakeLists.txt
+++ b/examples/ImGuiPlatform/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(
   ${srcs}
 )
 
-target_compile_features(ImGuiPlatform PUBLIC cxx_std_11)
+target_compile_features(ImGuiPlatform PUBLIC cxx_std_14)
 
 target_include_directories(
   ImGuiPlatform

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ add_library(LLGI STATIC ${files})
 
 file(GLOB LOCAL_HEADERS *.h)
 set_target_properties(LLGI PROPERTIES PUBLIC_HEADER "${LOCAL_HEADERS}")
-target_compile_features(LLGI PUBLIC cxx_std_11)
+target_compile_features(LLGI PUBLIC cxx_std_14)
 
 if(BUILD_VULKAN)
   find_package(Vulkan REQUIRED)

--- a/tools/ShaderTranspiler/CMakeLists.txt
+++ b/tools/ShaderTranspiler/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ShaderTranspiler)
 
 add_executable(ShaderTranspiler main.cpp)
 
-target_compile_features(ShaderTranspiler PUBLIC cxx_std_11)
+target_compile_features(ShaderTranspiler PUBLIC cxx_std_14)
 
 target_include_directories(ShaderTranspiler PUBLIC ../ShaderTranspilerCore)
 

--- a/tools/ShaderTranspilerCore/CMakeLists.txt
+++ b/tools/ShaderTranspilerCore/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(
   ShaderTranspilerCore STATIC ShaderTranspilerCore.cpp ShaderTranspilerCore.h
                               ResourceLimits.cpp ResourceLimits.h)
 
-target_compile_features(ShaderTranspilerCore PUBLIC cxx_std_11)
+target_compile_features(ShaderTranspilerCore PUBLIC cxx_std_14)
 target_include_directories(ShaderTranspilerCore
                            PUBLIC ${LLGI_THIRDPARTY_INCLUDES})
 


### PR DESCRIPTION
The deprecated attribute, which is used in [here](https://github.com/altseed/LLGI/blob/99fce2ec2e45f79239d0d525aa502ded906595fc/src/LLGI.Texture.h#L26) is only available in C++14 and after.
How about change the build option from c++11 to c++14?
