### PR TITLE
Use override for destructors

### DIFF
--- a/examples/ImGuiPlatform/ImGuiPlatformMetal.h
+++ b/examples/ImGuiPlatform/ImGuiPlatformMetal.h
@@ -14,7 +14,7 @@ class ImguiPlatformMetal : public ImguiPlatform
 public:
 	ImguiPlatformMetal(LLGI::Graphics* g);
 
-	virtual ~ImguiPlatformMetal();
+	~ImguiPlatformMetal() override;
 
 	void NewFrame(LLGI::RenderPass* renderPass) override;
 

--- a/src/DX12/LLGI.CommandListDX12.h
+++ b/src/DX12/LLGI.CommandListDX12.h
@@ -41,7 +41,7 @@ private:
 
 public:
 	CommandListDX12();
-	virtual ~CommandListDX12();
+	~CommandListDX12() override;
 	bool Initialize(GraphicsDX12* graphics, int32_t drawingCount);
 
 	void Begin() override;

--- a/src/DX12/LLGI.CompilerDX12.h
+++ b/src/DX12/LLGI.CompilerDX12.h
@@ -33,7 +33,7 @@ private:
 
 public:
 	CompilerDX12(const CompilerDX12Option& option = LLGI::CompilerDX12Option::ColumnMajor);
-	virtual ~CompilerDX12() = default;
+	~CompilerDX12() override = default;
 
 	void Initialize() override;
 	void Compile(CompilerResult& result, const char* code, ShaderStageType shaderStage) override;

--- a/src/DX12/LLGI.ConstantBufferDX12.h
+++ b/src/DX12/LLGI.ConstantBufferDX12.h
@@ -25,7 +25,7 @@ public:
 	bool InitializeAsShortTime(SingleFrameMemoryPoolDX12* memoryPool, int32_t size);
 
 	ConstantBufferDX12();
-	virtual ~ConstantBufferDX12();
+	~ConstantBufferDX12() override;
 
 	void* Lock() override;
 	void* Lock(int32_t offset, int32_t size) override;

--- a/src/DX12/LLGI.GraphicsDX12.h
+++ b/src/DX12/LLGI.GraphicsDX12.h
@@ -38,7 +38,7 @@ public:
 				 ID3D12CommandQueue* commandQueue,
 				 int32_t swapBufferCount,
 				 ReferenceObject* owner = nullptr);
-	virtual ~GraphicsDX12();
+	~GraphicsDX12() override;
 
 	void Execute(CommandList* commandList) override;
 	void WaitFinish() override;

--- a/src/DX12/LLGI.IndexBufferDX12.h
+++ b/src/DX12/LLGI.IndexBufferDX12.h
@@ -22,7 +22,7 @@ public:
 	bool Initialize(GraphicsDX12* graphics, int32_t stride, int32_t count);
 
 	IndexBufferDX12();
-	virtual ~IndexBufferDX12();
+	~IndexBufferDX12() override;
 
 	virtual void* Lock();
 	virtual void* Lock(int32_t offset, int32_t size);

--- a/src/DX12/LLGI.PipelineStateDX12.h
+++ b/src/DX12/LLGI.PipelineStateDX12.h
@@ -28,7 +28,7 @@ private:
 public:
 	PipelineStateDX12() = default;
 	PipelineStateDX12(GraphicsDX12* graphics);
-	virtual ~PipelineStateDX12();
+	~PipelineStateDX12() override;
 
 	void SetShader(ShaderStageType stage, Shader* shader) override;
 	bool Compile() override;

--- a/src/DX12/LLGI.PlatformDX12.h
+++ b/src/DX12/LLGI.PlatformDX12.h
@@ -49,7 +49,7 @@ private:
 
 public:
 	PlatformDX12();
-	virtual ~PlatformDX12();
+	~PlatformDX12() override;
 
 	bool Initialize(Window* window, bool waitVSync);
 

--- a/src/DX12/LLGI.RenderPassDX12.h
+++ b/src/DX12/LLGI.RenderPassDX12.h
@@ -32,7 +32,7 @@ private:
 
 public:
 	RenderPassDX12(ID3D12Device* device);
-	virtual ~RenderPassDX12();
+	~RenderPassDX12() override;
 
 	bool Initialize(TextureDX12** textures,
 					int numTextures,

--- a/src/DX12/LLGI.RenderPassPipelineStateDX12.h
+++ b/src/DX12/LLGI.RenderPassPipelineStateDX12.h
@@ -16,7 +16,7 @@ class RenderPassPipelineStateDX12 : public RenderPassPipelineState
 private:
 public:
 	RenderPassPipelineStateDX12() = default;
-	virtual ~RenderPassPipelineStateDX12() = default;
+	~RenderPassPipelineStateDX12() override = default;
 };
 
 } // namespace LLGI

--- a/src/DX12/LLGI.ShaderDX12.h
+++ b/src/DX12/LLGI.ShaderDX12.h
@@ -17,7 +17,7 @@ private:
 
 public:
 	ShaderDX12() = default;
-	virtual ~ShaderDX12() = default;
+	~ShaderDX12() override = default;
 
 	bool Initialize(DataStructure* data, int32_t count);
 

--- a/src/DX12/LLGI.SingleFrameMemoryPoolDX12.h
+++ b/src/DX12/LLGI.SingleFrameMemoryPoolDX12.h
@@ -38,7 +38,7 @@ private:
 public:
 	SingleFrameMemoryPoolDX12(
 		GraphicsDX12* graphics, bool isStrongRef, int32_t swapBufferCount, int32_t constantBufferPoolSize, int32_t drawingCount);
-	virtual ~SingleFrameMemoryPoolDX12();
+	~SingleFrameMemoryPoolDX12() override;
 
 	bool GetConstantBuffer(int32_t size, ID3D12Resource*& resource, int32_t& offset);
 

--- a/src/DX12/LLGI.TextureDX12.h
+++ b/src/DX12/LLGI.TextureDX12.h
@@ -36,7 +36,7 @@ public:
 	//! init as screen texture
 	TextureDX12(ID3D12Resource* textureResource, ID3D12Device* device, ID3D12CommandQueue* commandQueue);
 
-	virtual ~TextureDX12();
+	~TextureDX12() override;
 
 	//! init as external texture
 	bool Initialize(ID3D12Resource* textureResource);

--- a/src/DX12/LLGI.VertexBufferDX12.h
+++ b/src/DX12/LLGI.VertexBufferDX12.h
@@ -19,7 +19,7 @@ public:
 	bool Initialize(GraphicsDX12* graphics, int32_t size);
 
 	VertexBufferDX12();
-	virtual ~VertexBufferDX12();
+	~VertexBufferDX12() override;
 
 	virtual void* Lock();
 	virtual void* Lock(int32_t offset, int32_t size);

--- a/src/LLGI.CommandList.h
+++ b/src/LLGI.CommandList.h
@@ -81,7 +81,7 @@ protected:
 
 public:
 	CommandList(int32_t swapCount = 3);
-	virtual ~CommandList();
+	~CommandList() override;
 
 	/**
 	@brief

--- a/src/LLGI.Compiler.h
+++ b/src/LLGI.Compiler.h
@@ -18,7 +18,7 @@ class Compiler : public ReferenceObject
 private:
 public:
 	Compiler() = default;
-	virtual ~Compiler() = default;
+	~Compiler() override = default;
 
 	virtual void Initialize();
 	virtual void Compile(CompilerResult& result, const char* code, ShaderStageType shaderStage);

--- a/src/LLGI.ConstantBuffer.h
+++ b/src/LLGI.ConstantBuffer.h
@@ -11,7 +11,7 @@ class ConstantBuffer : public ReferenceObject
 private:
 public:
 	ConstantBuffer() = default;
-	virtual ~ConstantBuffer() = default;
+	~ConstantBuffer() override = default;
 
 	/*[[deprecated("use CommandList::SetData.")]]*/ virtual void* Lock();
 

--- a/src/LLGI.Graphics.h
+++ b/src/LLGI.Graphics.h
@@ -59,7 +59,7 @@ protected:
 
 public:
 	SingleFrameMemoryPool(int32_t swapBufferCount = 3);
-	virtual ~SingleFrameMemoryPool();
+	~SingleFrameMemoryPool() override;
 
 	/**
 	@brief	Start new frame
@@ -152,7 +152,7 @@ protected:
 
 public:
 	RenderPass() = default;
-	virtual ~RenderPass();
+	~RenderPass() override;
 
 	virtual bool GetIsColorCleared() const { return isColorCleared_; }
 
@@ -193,7 +193,7 @@ class RenderPassPipelineState : public ReferenceObject
 private:
 public:
 	RenderPassPipelineState() = default;
-	virtual ~RenderPassPipelineState() = default;
+	~RenderPassPipelineState() override = default;
 	RenderPassPipelineStateKey Key;
 };
 
@@ -209,7 +209,7 @@ protected:
 
 public:
 	Graphics() = default;
-	virtual ~Graphics();
+	~Graphics() override;
 
 	/*[[deprecated("use Platform::SetWindowSize.")]]*/ virtual void SetWindowSize(const Vec2I& windowSize);
 

--- a/src/LLGI.IndexBuffer.h
+++ b/src/LLGI.IndexBuffer.h
@@ -11,7 +11,7 @@ class IndexBuffer : public ReferenceObject
 private:
 public:
 	IndexBuffer() = default;
-	virtual ~IndexBuffer() = default;
+	~IndexBuffer() override = default;
 
 	/*[[deprecated("use CommandList::SetData.")]]*/ virtual void* Lock();
 

--- a/src/LLGI.PipelineState.h
+++ b/src/LLGI.PipelineState.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 	PipelineState();
-	virtual ~PipelineState() = default;
+	~PipelineState() override = default;
 
 	CullingMode Culling = CullingMode::Clockwise;
 	TopologyType Topology = TopologyType::Triangle;

--- a/src/LLGI.Platform.h
+++ b/src/LLGI.Platform.h
@@ -28,7 +28,7 @@ protected:
 
 public:
 	Platform() = default;
-	virtual ~Platform() = default;
+	~Platform() override = default;
 
 	virtual bool NewFrame();
 	virtual void Present();

--- a/src/LLGI.Shader.h
+++ b/src/LLGI.Shader.h
@@ -11,7 +11,7 @@ class Shader : public ReferenceObject
 private:
 public:
 	Shader() = default;
-	virtual ~Shader() = default;
+	~Shader() override = default;
 };
 
 } // namespace LLGI

--- a/src/LLGI.Texture.h
+++ b/src/LLGI.Texture.h
@@ -16,7 +16,7 @@ protected:
 
 public:
 	Texture() = default;
-	virtual ~Texture() = default;
+	~Texture() override = default;
 
 	/*[[deprecated("use CommandList::SetImageData2D.")]]*/ virtual void* Lock();
 

--- a/src/LLGI.VertexBuffer.h
+++ b/src/LLGI.VertexBuffer.h
@@ -11,7 +11,7 @@ class VertexBuffer : public ReferenceObject
 private:
 public:
 	VertexBuffer() = default;
-	virtual ~VertexBuffer() = default;
+	~VertexBuffer() override = default;
 
 	/*[[deprecated("use CommandList::SetData.")]]*/ virtual void* Lock();
 

--- a/src/Linux/LLGI.WindowLinux.h
+++ b/src/Linux/LLGI.WindowLinux.h
@@ -24,7 +24,7 @@ private:
 public:
 	WindowLinux() = default;
 
-	virtual ~WindowLinux();
+	~WindowLinux() override;
 
 	bool Initialize(const char* title, const Vec2I& windowSize);
 

--- a/src/Mac/LLGI.WindowMac.h
+++ b/src/Mac/LLGI.WindowMac.h
@@ -17,7 +17,7 @@ private:
 public:
 	WindowMac() = default;
 
-	virtual ~WindowMac() = default;
+	~WindowMac() override = default;
 
 	bool Initialize(const char* title, const Vec2I& windowSize);
 

--- a/src/Metal/LLGI.BufferMetal.h
+++ b/src/Metal/LLGI.BufferMetal.h
@@ -17,7 +17,7 @@ private:
 
 public:
 	BufferMetal();
-	virtual ~BufferMetal();
+	~BufferMetal() override;
 
 	bool Initialize(Graphics* graphics, int32_t size);
 

--- a/src/Metal/LLGI.CommandListMetal.h
+++ b/src/Metal/LLGI.CommandListMetal.h
@@ -24,7 +24,7 @@ class CommandListMetal : public CommandList
 
 public:
 	CommandListMetal();
-	virtual ~CommandListMetal();
+	~CommandListMetal() override;
 
 	bool Initialize(Graphics* graphics);
 

--- a/src/Metal/LLGI.ConstantBufferMetal.h
+++ b/src/Metal/LLGI.ConstantBufferMetal.h
@@ -17,7 +17,7 @@ private:
 
 public:
 	ConstantBufferMetal();
-	virtual ~ConstantBufferMetal();
+	~ConstantBufferMetal() override;
 
 	bool Initialize(Graphics* graphics, int32_t size);
 

--- a/src/Metal/LLGI.GraphicsMetal.h
+++ b/src/Metal/LLGI.GraphicsMetal.h
@@ -37,7 +37,7 @@ class GraphicsMetal : public Graphics
 
 public:
 	GraphicsMetal();
-	virtual ~GraphicsMetal();
+	~GraphicsMetal() override;
 
 	bool Initialize(std::function<GraphicsView()> getGraphicsView);
 

--- a/src/Metal/LLGI.IndexBufferMetal.h
+++ b/src/Metal/LLGI.IndexBufferMetal.h
@@ -16,7 +16,7 @@ private:
 
 public:
 	IndexBufferMetal();
-	virtual ~IndexBufferMetal();
+	~IndexBufferMetal() override;
 
 	bool Initialize(Graphics* graphics, int32_t stride, int32_t count);
 

--- a/src/Metal/LLGI.PipelineStateMetal.h
+++ b/src/Metal/LLGI.PipelineStateMetal.h
@@ -19,7 +19,7 @@ private:
 
 public:
 	PipelineStateMetal();
-	virtual ~PipelineStateMetal();
+	~PipelineStateMetal() override;
 
 	bool Initialize(GraphicsMetal* graphics);
 	void SetShader(ShaderStageType stage, Shader* shader) override;

--- a/src/Metal/LLGI.PlatformMetal.h
+++ b/src/Metal/LLGI.PlatformMetal.h
@@ -29,7 +29,7 @@ class PlatformMetal : public Platform
 
 public:
 	PlatformMetal(Window* window, bool waitVSync);
-	~PlatformMetal();
+	~PlatformMetal() override;
 	bool NewFrame() override;
 	void Present() override;
 	Graphics* CreateGraphics() override;

--- a/src/Metal/LLGI.RenderPassMetal.h
+++ b/src/Metal/LLGI.RenderPassMetal.h
@@ -24,7 +24,7 @@ class RenderPassMetal : public RenderPass
 public:
 	RenderPassMetal();
 
-	virtual ~RenderPassMetal();
+	~RenderPassMetal() override;
 
 	bool UpdateRenderTarget(
 		Texture** textures, int32_t textureCount, Texture* depthTexture, Texture* resolvedTexture, Texture* resolvedDepthTexture);
@@ -45,7 +45,7 @@ private:
 
 public:
 	RenderPassPipelineStateMetal();
-	virtual ~RenderPassPipelineStateMetal();
+	~RenderPassPipelineStateMetal() override;
 
 	void SetKey(const RenderPassPipelineStateKey& key);
 

--- a/src/Metal/LLGI.ShaderMetal.h
+++ b/src/Metal/LLGI.ShaderMetal.h
@@ -17,7 +17,7 @@ private:
 
 public:
 	ShaderMetal();
-	virtual ~ShaderMetal();
+	~ShaderMetal() override;
 	bool Initialize(GraphicsMetal* graphics, DataStructure* data, int32_t count);
 
 	Shader_Impl* GetImpl() { return impl; }

--- a/src/Metal/LLGI.SingleFrameMemoryPoolMetal.h
+++ b/src/Metal/LLGI.SingleFrameMemoryPoolMetal.h
@@ -45,7 +45,7 @@ private:
 
 public:
 	SingleFrameMemoryPoolMetal(GraphicsMetal* graphics, bool isStrongRef, int32_t constantBufferPoolSize, int32_t drawingCount);
-	virtual ~SingleFrameMemoryPoolMetal();
+	~SingleFrameMemoryPoolMetal() override;
 	virtual void NewFrame() override;
 };
 

--- a/src/Metal/LLGI.TextureMetal.h
+++ b/src/Metal/LLGI.TextureMetal.h
@@ -18,7 +18,7 @@ private:
 
 public:
 	TextureMetal();
-	virtual ~TextureMetal();
+	~TextureMetal() override;
 
 	bool Initialize(GraphicsMetal* owner, const TextureInitializationParameter& parameter);
 	bool Initialize(GraphicsMetal* owner, const RenderTextureInitializationParameter& parameter);

--- a/src/Metal/LLGI.VertexBufferMetal.h
+++ b/src/Metal/LLGI.VertexBufferMetal.h
@@ -14,7 +14,7 @@ private:
 
 public:
 	VertexBufferMetal();
-	virtual ~VertexBufferMetal();
+	~VertexBufferMetal() override;
 
 	bool Initialize(Graphics* graphics, int32_t size);
 

--- a/src/Vulkan/LLGI.CommandListVulkan.h
+++ b/src/Vulkan/LLGI.CommandListVulkan.h
@@ -40,7 +40,7 @@ private:
 
 public:
 	CommandListVulkan();
-	virtual ~CommandListVulkan();
+	~CommandListVulkan() override;
 
 	bool
 	Initialize(GraphicsVulkan* graphics, int32_t drawingCount, CommandListPreCondition precondition = CommandListPreCondition::Standalone);

--- a/src/Vulkan/LLGI.CompilerVulkan.h
+++ b/src/Vulkan/LLGI.CompilerVulkan.h
@@ -12,7 +12,7 @@ class CompilerVulkan : public Compiler
 private:
 public:
 	CompilerVulkan();
-	virtual ~CompilerVulkan();
+	~CompilerVulkan() override;
 
 	void Initialize() override;
 	void Compile(CompilerResult& result, const char* code, ShaderStageType shaderStage) override;

--- a/src/Vulkan/LLGI.ConstantBufferVulkan.h
+++ b/src/Vulkan/LLGI.ConstantBufferVulkan.h
@@ -20,7 +20,7 @@ private:
 
 public:
 	ConstantBufferVulkan();
-	virtual ~ConstantBufferVulkan();
+	~ConstantBufferVulkan() override;
 
 	bool Initialize(GraphicsVulkan* graphics, int32_t size);
 	bool InitializeAsShortTime(GraphicsVulkan* graphics, SingleFrameMemoryPoolVulkan* memoryPool, int32_t size);

--- a/src/Vulkan/LLGI.GraphicsVulkan.h
+++ b/src/Vulkan/LLGI.GraphicsVulkan.h
@@ -38,7 +38,7 @@ public:
 				   RenderPassPipelineStateCacheVulkan* renderPassPipelineStateCache = nullptr,
 				   ReferenceObject* owner = nullptr);
 
-	virtual ~GraphicsVulkan();
+	~GraphicsVulkan() override;
 
 	void SetWindowSize(const Vec2I& windowSize) override;
 

--- a/src/Vulkan/LLGI.IndexBufferVulkan.h
+++ b/src/Vulkan/LLGI.IndexBufferVulkan.h
@@ -23,7 +23,7 @@ public:
 	bool Initialize(GraphicsVulkan* graphics, int32_t stride, int32_t count);
 
 	IndexBufferVulkan();
-	virtual ~IndexBufferVulkan();
+	~IndexBufferVulkan() override;
 
 	void* Lock() override;
 	void* Lock(int32_t offset, int32_t size) override;

--- a/src/Vulkan/LLGI.PipelineStateVulkan.h
+++ b/src/Vulkan/LLGI.PipelineStateVulkan.h
@@ -20,7 +20,7 @@ private:
 
 public:
 	PipelineStateVulkan();
-	virtual ~PipelineStateVulkan();
+	~PipelineStateVulkan() override;
 
 	bool Initialize(GraphicsVulkan* graphics);
 

--- a/src/Vulkan/LLGI.PlatformVulkan.h
+++ b/src/Vulkan/LLGI.PlatformVulkan.h
@@ -122,7 +122,7 @@ private:
 
 public:
 	PlatformVulkan();
-	virtual ~PlatformVulkan();
+	~PlatformVulkan() override;
 
 	bool Initialize(Window* window, bool waitVSync);
 

--- a/src/Vulkan/LLGI.RenderPassPipelineStateCacheVulkan.h
+++ b/src/Vulkan/LLGI.RenderPassPipelineStateCacheVulkan.h
@@ -21,7 +21,7 @@ private:
 
 public:
 	RenderPassPipelineStateCacheVulkan(vk::Device device, ReferenceObject* owner);
-	virtual ~RenderPassPipelineStateCacheVulkan();
+	~RenderPassPipelineStateCacheVulkan() override;
 
 	RenderPassPipelineStateVulkan* Create(const RenderPassPipelineStateKey key);
 };

--- a/src/Vulkan/LLGI.RenderPassVulkan.h
+++ b/src/Vulkan/LLGI.RenderPassVulkan.h
@@ -40,7 +40,7 @@ public:
 	vk::Image depthBuffer;
 
 	RenderPassVulkan(RenderPassPipelineStateCacheVulkan* renderPassPipelineStateCache, vk::Device device, ReferenceObject* owner);
-	virtual ~RenderPassVulkan();
+	~RenderPassVulkan() override;
 
 	bool Initialize(const TextureVulkan** textures,
 					int32_t textureCount,
@@ -67,7 +67,7 @@ private:
 public:
 	RenderPassPipelineStateVulkan(vk::Device device, ReferenceObject* owner);
 
-	virtual ~RenderPassPipelineStateVulkan();
+	~RenderPassPipelineStateVulkan() override;
 
 	vk::RenderPass renderPass_;
 	int32_t RenderTargetCount = 0;

--- a/src/Vulkan/LLGI.ShaderVulkan.h
+++ b/src/Vulkan/LLGI.ShaderVulkan.h
@@ -17,7 +17,7 @@ private:
 
 public:
 	ShaderVulkan();
-	virtual ~ShaderVulkan();
+	~ShaderVulkan() override;
 
 	bool Initialize(GraphicsVulkan* graphics, DataStructure* data, int count);
 

--- a/src/Vulkan/LLGI.SingleFrameMemoryPoolVulkan.h
+++ b/src/Vulkan/LLGI.SingleFrameMemoryPoolVulkan.h
@@ -43,7 +43,7 @@ protected:
 public:
 	SingleFrameMemoryPoolVulkan(
 		GraphicsVulkan* graphics, bool isStrongRef, int32_t swapBufferCount, int32_t constantBufferPoolSize, int32_t drawingCount);
-	virtual ~SingleFrameMemoryPoolVulkan();
+	~SingleFrameMemoryPoolVulkan() override;
 
 	bool GetConstantBuffer(int32_t size, VkBuffer* outResource, VkDeviceMemory* deviceMemory, int32_t* outOffset);
 

--- a/src/Vulkan/LLGI.TextureVulkan.h
+++ b/src/Vulkan/LLGI.TextureVulkan.h
@@ -34,7 +34,7 @@ private:
 
 public:
 	TextureVulkan();
-	virtual ~TextureVulkan();
+	~TextureVulkan() override;
 
 	bool Initialize(
 		GraphicsVulkan* graphics, bool isStrongRef, const Vec2I& size, vk::Format format, int samplingCount, TextureType textureType);

--- a/src/Vulkan/LLGI.VertexBufferVulkan.h
+++ b/src/Vulkan/LLGI.VertexBufferVulkan.h
@@ -23,7 +23,7 @@ public:
 	bool InitializeAsShortTime(SingleFrameMemoryPoolVulkan* memoryPool, int32_t size);
 
 	VertexBufferVulkan();
-	virtual ~VertexBufferVulkan();
+	~VertexBufferVulkan() override;
 
 	void* Lock() override;
 	void* Lock(int32_t offset, int32_t size) override;

--- a/src/Win/LLGI.WindowWin.h
+++ b/src/Win/LLGI.WindowWin.h
@@ -18,7 +18,7 @@ private:
 public:
 	WindowWin() = default;
 
-	virtual ~WindowWin();
+	~WindowWin() override;
 
 	bool Initialize(const char* title, const Vec2I& windowSize);
 


### PR DESCRIPTION
In modern C++, explicit override deceleration is preferred.