### PR TITLE
CMake suggestions for build/install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 # The project's name
 project(LLGI)
 
+include(GNUInstallDirs)
 include(ExternalProject)
 
 # linux flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,19 +239,19 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
 endif()
 
 if(BUILD_VULKAN)
-  add_definitions(-DENABLE_VULKAN)
+  add_compile_definitions(ENABLE_VULKAN)
 
   if(GLSLANG_WITHOUT_INSTALL)
-    add_compile_definitions(LLGI PRIVATE ENABLE_GLSLANG_WITHOUT_INSTALL)
+    add_compile_definitions(ENABLE_GLSLANG_WITHOUT_INSTALL)
   endif()
 
   if(BUILD_VULKAN_COMPILER)
-    add_definitions(-DENABLE_VULKAN_COMPILER)
+    add_compile_definitions(ENABLE_VULKAN_COMPILER)
   endif()
 endif()
 
 if(APPLE)
-  add_definitions(-DENABLE_METAL)
+  add_compile_definitions(ENABLE_METAL)
 endif()
 
 add_subdirectory("src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ else()
 endif()
 
 if(MSVC)
-  target_compile_options(LLGI PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(LLGI PRIVATE /W4 /WX /wd4100)
 else()
   target_compile_options(LLGI PRIVATE -Wall -Werror)
 endif()

--- a/src_test/CMakeLists.txt
+++ b/src_test/CMakeLists.txt
@@ -45,7 +45,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Shaders
 clang_format(LLGI_Test)
 
 if(MSVC)
-  target_compile_options(LLGI_Test PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(LLGI_Test PRIVATE /W4 /WX /wd4100)
 else()
   target_compile_options(LLGI_Test PRIVATE -Wall -Werror)
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(ShaderTranspilerCore)
 add_subdirectory(ShaderTranspiler)
+install(TARGETS ShaderTranspiler DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/ShaderTranspiler/CMakeLists.txt
+++ b/tools/ShaderTranspiler/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(ShaderTranspiler PUBLIC ../ShaderTranspilerCore)
 target_link_libraries(ShaderTranspiler PUBLIC ShaderTranspilerCore)
 
 if(MSVC)
-  target_compile_options(ShaderTranspiler PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(ShaderTranspiler PRIVATE /W4 /WX /wd4100)
 else()
   target_compile_options(ShaderTranspiler PRIVATE -Wall -Werror)
 endif()

--- a/tools/ShaderTranspilerCore/CMakeLists.txt
+++ b/tools/ShaderTranspilerCore/CMakeLists.txt
@@ -35,9 +35,9 @@ else()
 endif()
 
 if(GLSLANG_WITHOUT_INSTALL)
-  add_compile_definitions(ShaderTranspilerCore ENABLE_GLSLANG_WITHOUT_INSTALL)
+  target_compile_definitions(ShaderTranspilerCore PRIVATE ENABLE_GLSLANG_WITHOUT_INSTALL)
 endif()
 
 if(SPIRVCROSS_WITHOUT_INSTALL)
-  add_compile_definitions(ShaderTranspilerCore ENABLE_SPIRVCROSS_WITHOUT_INSTALL)
+  target_compile_definitions(ShaderTranspilerCore PRIVATE ENABLE_SPIRVCROSS_WITHOUT_INSTALL)
 endif()

--- a/tools/ShaderTranspilerCore/CMakeLists.txt
+++ b/tools/ShaderTranspilerCore/CMakeLists.txt
@@ -29,7 +29,7 @@ if(USE_THIRDPARTY_DIRECTORY)
 endif()
 
 if(MSVC)
-  target_compile_options(ShaderTranspilerCore PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(ShaderTranspilerCore PRIVATE /W4 /WX /wd4100)
 else()
   target_compile_options(ShaderTranspilerCore PRIVATE -Wall -Werror)
 endif()


### PR DESCRIPTION
## Changes

### 1. Fix CMake compile definitions

The following was adding macro `LLGI`, which hides `namespace LLGI` in C++ sources

https://github.com/altseed/LLGI/blob/008fe7fc7d1c427f476c2e8ca654c590cd38c39a/CMakeLists.txt#L244-L246

And,

* Replaced some `add_definitions(-D*` to `add_compile_definitions`
* If target name is used, use `target_compile_definitions` instead of `add_compile_definitions`

### 2. Install `ShaderTranspiler` tool

Uses `GNUInstallDirs` and `CMAKE_INSTALL_BINDIR`


### 3. Remove "" from `/wd"4100"`

Causing an error D8021 like the following

```log
FAILED: src/CMakeFiles/LLGI.dir/Win/LLGI.WindowWin.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\cl.exe   /TP -DENABLE_CREATE_COMPILER  /DNOMINMAX  /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -MDd /W4 /WX /wd\"4100\" /showIncludes /Fosrc\CMakeFiles\LLGI.dir\Win\LLGI.WindowWin.cpp.obj /Fdsrc\CMakeFiles\LLGI.dir\LLGI.pdb /FS -c C:\vcpkg\buildtrees\llgi\src\90cd38c39a-2aa0a577b3\src\Win\LLGI.WindowWin.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
cl : Command line error D8021 : invalid numeric argument '/wd"4100"'
```