### PR TITLE
Avoid when depth buffer creation fails

### DIFF
--- a/src/Vulkan/LLGI.PlatformVulkan.cpp
+++ b/src/Vulkan/LLGI.PlatformVulkan.cpp
@@ -181,11 +181,19 @@ bool PlatformVulkan::CreateDepthBuffer(Vec2I windowSize)
 	param.Size = {windowSize.X, windowSize.Y, 1};
 
 	depthStencilTexture_ = new TextureVulkan();
-	if (!depthStencilTexture_->Initialize(nullptr, vkDevice_, vkPhysicalDevice, nullptr, param))
+	if (depthStencilTexture_->Initialize(nullptr, vkDevice_, vkPhysicalDevice, nullptr, param))
 	{
-		return false;
+		return true;
 	}
-	return true;
+
+	// Avoid when depth buffer creation fails (occurs on AMD GPUs).
+	param.Format = TextureFormatType::D32S8;
+	if (depthStencilTexture_->Initialize(nullptr, vkDevice_, vkPhysicalDevice, nullptr, param))
+	{
+		return true;
+	}
+
+	return false;
 }
 
 void PlatformVulkan::CreateRenderPass()

--- a/src/Vulkan/LLGI.TextureVulkan.cpp
+++ b/src/Vulkan/LLGI.TextureVulkan.cpp
@@ -90,7 +90,7 @@ bool TextureVulkan::Initialize(GraphicsVulkan* graphics,
 		vk::FormatProperties formatProps = physicalDevice.getFormatProperties((vk::Format)vkFormat);
 		if (!(formatProps.optimalTilingFeatures & vk::FormatFeatureFlagBits::eDepthStencilAttachment))
 		{
-			throw "Invalid formatProps";
+			return false;
 		}
 	}
 	else


### PR DESCRIPTION
Avoid when depth buffer creation fails by Vulkan on AMD GPUs.

### Environment
DeviceType: Vulkan
OS: Windows 11
GPU: AMD Radeon 680M
